### PR TITLE
Status indicator feature + bug fixes

### DIFF
--- a/chathaven/backend/src/controllers/usersController.ts
+++ b/chathaven/backend/src/controllers/usersController.ts
@@ -180,3 +180,38 @@ export const deleteUser = async (req: Request, res: Response) => {
     console.error('Failed to delete user', errorMessage);
   }
 };
+
+/**
+ * Update the user's status
+ * @param req userId, status
+ * @param res returns success or error message
+ */
+export const updateStatus = async (req: Request, res: Response) => {
+  try {
+    const { userId, status } = req.body;
+
+    const user = await User.findOne({ userId });
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    user.status = status;
+    await user.save();
+
+    res.json({ 
+      success: true ,
+      message:
+        `The user status has been updated successfully to ${status}`,
+    });
+
+  } catch (error: any) {
+    const errorMessage = error.message;
+    res.status(500).json({
+      success: false,
+      error: 'Failed to update status',
+      details: errorMessage,
+    });
+    console.error('Failed to update status', errorMessage);
+  }
+};

--- a/chathaven/backend/src/models/userModel.ts
+++ b/chathaven/backend/src/models/userModel.ts
@@ -19,6 +19,8 @@ const userSchema: Schema = new Schema(
     teams: { type: [String], default: [] }, // List of team IDs
     directMessages: { type: [String], default: [] },
     inbox: { type: [inboxSchema], default: [] }, // Set default to an empty object
+    status: { type: String, default: "online" }, // online, offline, away
+    lastSeen: { type: Date, default: Date.now },
   },
   {
     collection: 'Users',

--- a/chathaven/backend/src/routes/userRoutes.ts
+++ b/chathaven/backend/src/routes/userRoutes.ts
@@ -3,6 +3,7 @@ import {
   getUserById,
   getUserByUsername,
   deleteUser,
+  updateStatus,
 } from '../controllers/usersController';
 
 const router: Router = Router();
@@ -10,5 +11,6 @@ const router: Router = Router();
 router.get('/:userId', getUserById);
 router.get('/search/:username', getUserByUsername);
 router.delete('/delete/:userId', deleteUser);
+router.post('/status', updateStatus);
 
 export default router;

--- a/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.css
@@ -229,6 +229,8 @@ h3 h4 {
   align-items: center;
   justify-content: center;
   gap: 10px;
+  transform: translateZ(0);
+  backface-visibility: hidden;
 }
 
 .inbox-information {
@@ -313,6 +315,8 @@ h3 h4 {
   height: 8px;
   border-radius: 50%;
   margin-right: 5px;
+  will-change: background-color;
+  transition: background-color 0.2s ease-out;
 }
 
 .status-online {
@@ -325,4 +329,9 @@ h3 h4 {
 
 .status-offline {
   background-color: #808080;
+}
+
+.member-name {
+  will-change: transform;
+  transform: translateZ(0);
 }

--- a/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.css
@@ -307,3 +307,22 @@ h3 h4 {
     box-shadow: 0 0 0 14px #69ffa800;
   }
 }
+
+.status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 5px;
+}
+
+.status-online {
+  background-color: #44b700;
+}
+
+.status-away {
+  background-color: #ffa600ec;
+}
+
+.status-offline {
+  background-color: #808080;
+}

--- a/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.css
@@ -316,7 +316,7 @@ h3 h4 {
   border-radius: 50%;
   margin-right: 5px;
   will-change: background-color;
-  transition: background-color 0.2s ease-out;
+  transition: background-color 0.1s ease-out;
 }
 
 .status-online {

--- a/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.html
+++ b/chathaven/frontend/src/app/components/chat/component/informationSideBar/informationSideBar.component.html
@@ -65,6 +65,7 @@
         <ul>
           <li *ngFor="let member of teamMemberList" >
             <div class="user-information">
+              <div class="status-indicator" [ngClass]="'status-' + member.status"></div>
               <i class="fas fa-user-circle member-icon" style="margin: 2px"></i>
               <div class="member-name">{{ member.username }}</div>
             </div>
@@ -90,6 +91,7 @@
         <ul>
           <li *ngFor="let member of chatMemberList" >
             <div class="user-information">
+              <div class="status-indicator" [ngClass]="'status-' + member.status"></div>
               <i class="fas fa-user-circle member-icon" style="margin: 2px"></i>
               <div class="member-name">{{ member.username }}</div>
             </div>

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
@@ -328,7 +328,7 @@
 }
 
 .status-menu-container {
-  position: relative;
+  position: absolute;
   display: inline-block;
 }
 
@@ -346,6 +346,10 @@
   padding: 8px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   margin-bottom: 8px;
+  z-index: 30;
+  width: 120px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .status-toggle-checkbox:checked ~ .status-options {
@@ -372,4 +376,27 @@
 
 .status-option span {
   font-size: 14px;
+}
+
+.status-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.status-online {
+  background-color: #44b700;
+}
+
+.status-away {
+  background-color: #ffa600;
+}
+
+.status-offline {
+  background-color: #808080;
+}
+
+.menu-toggle-checkbox:checked ~ .status-menu-container {
+  transition-delay: 0.2s;
+  transform: translateY(-65px) translateX(65px);
 }

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
@@ -363,7 +363,10 @@
   z-index: 30;
   width: 120px;
   left: 50%;
-  transform: translateX(10%), translateY(-25%);
+  transform: translateX(50%), translateY(-25%);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14px;
+
 }
 
 .status-toggle-checkbox:checked ~ .status-options {
@@ -390,6 +393,8 @@
 
 .status-option span {
   font-size: 14px;
+  font-family: Arial, Helvetica, sans-serif;
+  font-weight: 500; 
 }
 
 .status-indicator {
@@ -403,7 +408,7 @@
 }
 
 .status-away {
-  background-color: #ffa600;
+  background-color: #ffa600da;
 }
 
 .status-offline {

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
@@ -344,7 +344,7 @@
   opacity: 0;  
   visibility: hidden;  
   transition: opacity 0.3s, visibility 0.3s, transform 0.3s;  
-  transition: all 0.3s ease-out;
+  z-index: 25; /* Increase z-index to make sure it stays above other elements */
 }
 
 .status-toggle-checkbox {
@@ -372,6 +372,12 @@
 
 .status-toggle-checkbox:checked ~ .status-options {
   display: block;
+}
+
+/* Add this to ensure the status menu stays visible independent of main menu */
+.menu-toggle-checkbox:not(:checked) ~ .status-menu-container {
+  /* Only control position, not visibility */
+  transform: translateY(0) translateX(40px);
 }
 
 .status-option {

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
@@ -211,6 +211,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  transition: all 0.3s ease-out;
 }
 
 .menu-toggle-checkbox:checked ~ .menu-option {
@@ -342,8 +343,8 @@
   display: inline-block;
   opacity: 0;  
   visibility: hidden;  
-
   transition: opacity 0.3s, visibility 0.3s, transform 0.3s;  
+  transition: all 0.3s ease-out;
 }
 
 .status-toggle-checkbox {
@@ -366,7 +367,7 @@
   transform: translateX(50%), translateY(-25%);
   font-family: Arial, Helvetica, sans-serif;
   font-size: 14px;
-
+  transition: display 0.3s ease-out;
 }
 
 .status-toggle-checkbox:checked ~ .status-options {

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
@@ -208,10 +208,13 @@
   -webkit-box-shadow: 3px 3px 10px 0px rgba(16, 16, 16, 0.5);
   -moz-box-shadow: 3px 3px 10px 0px rgba(16, 16, 16, 0.5);
   box-shadow: 3px 3px 10px 0px rgba(16, 16, 16, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .menu-toggle-checkbox:checked ~ .menu-option {
-  z-index: 15; /* Bring options above button when checked */
+  z-index: 15;
 }
 .menu-toggle-checkbox:hover ~ .menu-toggle-button,
 .menu-toggle-checkbox:checked ~ .menu-toggle-button {
@@ -250,6 +253,13 @@
 .menu-toggle-checkbox:checked ~ .menu-option-2 {
   transition-delay: 0.2s;
   transform: translateY(-65px) translateX(65px);
+}
+
+.menu-toggle-checkbox:checked ~ .status-menu-container {
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0.2s;
+  transform: translateY(-90px) translateX(40px);
 }
 
 .menu-toggle-checkbox:checked ~ .menu-option-3 {
@@ -330,6 +340,10 @@
 .status-menu-container {
   position: absolute;
   display: inline-block;
+  opacity: 0;  
+  visibility: hidden;  
+
+  transition: opacity 0.3s, visibility 0.3s, transform 0.3s;  
 }
 
 .status-toggle-checkbox {
@@ -349,7 +363,7 @@
   z-index: 30;
   width: 120px;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(10%), translateY(-25%);
 }
 
 .status-toggle-checkbox:checked ~ .status-options {
@@ -396,7 +410,3 @@
   background-color: #808080;
 }
 
-.menu-toggle-checkbox:checked ~ .status-menu-container {
-  transition-delay: 0.2s;
-  transform: translateY(-65px) translateX(65px);
-}

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
@@ -387,7 +387,8 @@
 }
 
 .status-option:hover {
-  background: var(--menu-hover);
+  background-color: var(--team-setting-list-element-background-hover);
+  color: var(--channel-list-text-hover);
   border-radius: 4px;
 }
 

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.css
@@ -326,3 +326,50 @@
     opacity: 1;
   }
 }
+
+.status-menu-container {
+  position: relative;
+  display: inline-block;
+}
+
+.status-toggle-checkbox {
+  display: none;
+}
+
+.status-options {
+  display: none;
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  background: var(--menu-background);
+  border-radius: 8px;
+  padding: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  margin-bottom: 8px;
+}
+
+.status-toggle-checkbox:checked ~ .status-options {
+  display: block;
+}
+
+.status-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  width: 100%;
+  border: none;
+  background: none;
+  color: var(--menu-text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.status-option:hover {
+  background: var(--menu-hover);
+  border-radius: 4px;
+}
+
+.status-option span {
+  font-size: 14px;
+}

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
@@ -87,15 +87,15 @@
         ></i>
       </label>
       <div class="status-options">
-        <button class="status-option" (click)="setStatus('online'); closeAllMenus(); $event.stopPropagation()">
+        <button class="status-option" (click)="setStatus('online', true); closeAllMenus(); $event.stopPropagation()">
           <div class="status-indicator status-online"></div>
           <span>Online</span>
         </button>
-        <button class="status-option" (click)="setStatus('away'); closeAllMenus(); $event.stopPropagation()">
+        <button class="status-option" (click)="setStatus('away', true); closeAllMenus(); $event.stopPropagation()">
           <div class="status-indicator status-away"></div>
           <span>Away</span>
         </button>
-        <button class="status-option" (click)="setStatus('offline'); closeAllMenus(); $event.stopPropagation()">
+        <button class="status-option" (click)="setStatus('offline', true); closeAllMenus(); $event.stopPropagation()">
           <div class="status-indicator status-offline"></div>
           <span>Offline</span>
         </button>

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
@@ -75,16 +75,32 @@
         readonly
       ></i>
     </button>
-    <!-- (click) user setting -->
-    <button class="menu-option-2 menu-option" readonly title="User Settings">
-      <i
-        class="fa fa-gear"
-        style="font-size: 24px; transition: transform 0.3s"
-        onmouseover="this.style.transform='rotate(90deg)'"
-        onmouseout="this.style.transform='rotate(0deg)'"
-        readonly
-      ></i>
-    </button>
+    <!-- User settings with status menu -->
+    <div class="status-menu-container">
+      <input type="checkbox" id="status-toggle" class="status-toggle-checkbox" />
+      <label for="status-toggle" class="menu-option-2 menu-option" title="User Settings">
+        <i
+          class="fa fa-gear"
+          style="font-size: 24px; transition: transform 0.3s"
+          onmouseover="this.style.transform='rotate(90deg)'"
+          onmouseout="this.style.transform='rotate(0deg)'"
+        ></i>
+      </label>
+      <div class="status-options">
+        <button class="status-option" (click)="setStatus('online')">
+          <div class="status-indicator status-online"></div>
+          <span>Online</span>
+        </button>
+        <button class="status-option" (click)="setStatus('away')">
+          <div class="status-indicator status-away"></div>
+          <span>Away</span>
+        </button>
+        <button class="status-option" (click)="setStatus('offline')">
+          <div class="status-indicator status-offline"></div>
+          <span>Offline</span>
+        </button>
+      </div>
+    </div>
     <!-- (click) sign out -->
     <button
       class="menu-option-3 menu-option"

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
@@ -87,15 +87,15 @@
         ></i>
       </label>
       <div class="status-options">
-        <button class="status-option" (click)="setStatus('online')">
+        <button class="status-option" (click)="setStatus('online'); closeAllMenus()">
           <div class="status-indicator status-online"></div>
           <span>Online</span>
         </button>
-        <button class="status-option" (click)="setStatus('away')">
+        <button class="status-option" (click)="setStatus('away'); closeAllMenus()">
           <div class="status-indicator status-away"></div>
           <span>Away</span>
         </button>
-        <button class="status-option" (click)="setStatus('offline')">
+        <button class="status-option" (click)="setStatus('offline'); closeAllMenus()">
           <div class="status-indicator status-offline"></div>
           <span>Offline</span>
         </button>

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.html
@@ -77,8 +77,8 @@
     </button>
     <!-- User settings with status menu -->
     <div class="status-menu-container">
-      <input type="checkbox" id="status-toggle" class="status-toggle-checkbox" />
-      <label for="status-toggle" class="menu-option-2 menu-option" title="User Settings">
+      <input type="checkbox" id="status-toggle" class="status-toggle-checkbox" (click)="$event.stopPropagation()" />
+      <label for="status-toggle" class="menu-option-2 menu-option" title="User Settings" (click)="$event.stopPropagation()">
         <i
           class="fa fa-gear"
           style="font-size: 24px; transition: transform 0.3s"
@@ -87,15 +87,15 @@
         ></i>
       </label>
       <div class="status-options">
-        <button class="status-option" (click)="setStatus('online'); closeAllMenus()">
+        <button class="status-option" (click)="setStatus('online'); closeAllMenus(); $event.stopPropagation()">
           <div class="status-indicator status-online"></div>
           <span>Online</span>
         </button>
-        <button class="status-option" (click)="setStatus('away'); closeAllMenus()">
+        <button class="status-option" (click)="setStatus('away'); closeAllMenus(); $event.stopPropagation()">
           <div class="status-indicator status-away"></div>
           <span>Away</span>
         </button>
-        <button class="status-option" (click)="setStatus('offline'); closeAllMenus()">
+        <button class="status-option" (click)="setStatus('offline'); closeAllMenus(); $event.stopPropagation()">
           <div class="status-indicator status-offline"></div>
           <span>Offline</span>
         </button>

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.ts
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.ts
@@ -192,4 +192,18 @@ export class TeamSidebarComponent implements OnInit, OnDestroy {
     this.userService.logout();
     this.router.navigate(['/home']);
   }
+
+  async closeAllMenus() {
+    // Clear the main menu checkbox
+    const menuToggle = document.querySelector('.menu-toggle-checkbox') as HTMLInputElement;
+    if (menuToggle) {
+      menuToggle.checked = false;
+    }
+
+    // Clear the status menu checkbox
+    const statusToggle = document.querySelector('.status-toggle-checkbox') as HTMLInputElement;
+    if (statusToggle) {
+      statusToggle.checked = false;
+    }
+  }
 }

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.ts
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.ts
@@ -1,7 +1,7 @@
 import { TeamCreationDialog } from '../../dialogue/create-team/create-team.dialogue';
 import { AddTeamMemberDialog } from '../../dialogue/add-member-team/add-member-team.dialogue';
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { ITeam, IUser } from '@shared/interfaces';
@@ -204,6 +204,18 @@ export class TeamSidebarComponent implements OnInit, OnDestroy {
     const statusToggle = document.querySelector('.status-toggle-checkbox') as HTMLInputElement;
     if (statusToggle) {
       statusToggle.checked = false;
+    }
+  }
+
+  @HostListener('document:click', ['$event'])
+  handleDocumentClick(event: MouseEvent): void {
+    // Don't close if clicking within the menu containers
+    const userMenuContainer = document.querySelector('.user-menu-container');
+    const statusMenuContainer = document.querySelector('.status-menu-container');
+    
+    if (userMenuContainer && !userMenuContainer.contains(event.target as Node) &&
+        statusMenuContainer && !statusMenuContainer.contains(event.target as Node)) {
+      this.closeAllMenus();
     }
   }
 }

--- a/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.ts
+++ b/chathaven/frontend/src/app/components/chat/component/teamSideBar/teamSideBar.component.ts
@@ -77,7 +77,10 @@ export class TeamSidebarComponent implements OnInit, OnDestroy {
     this.currentStatus = status;
     const user = this.userService.getUser();
     if (user) {
-      await this.backendService.updateStatus(user.userId, status);
+      const success = await this.backendService.updateStatus(user.userId, status);
+      if (success) {
+        await this.userService.updateUserStatus(status);
+      }
     }
   }
 

--- a/chathaven/frontend/src/app/components/login/login.component.ts
+++ b/chathaven/frontend/src/app/components/login/login.component.ts
@@ -294,7 +294,7 @@ export class LoginComponent implements OnInit {
           );
 
           if (user) {
-            this.userService.setUser(user);
+            await this.userService.setUser(user);
             this.goToChat();
           }
         } else if (response.error) {

--- a/chathaven/frontend/src/services/backend.service.ts
+++ b/chathaven/frontend/src/services/backend.service.ts
@@ -115,6 +115,26 @@ export class BackendService {
     return undefined;
   }
 
+  async updateStatus(userId: string, status: string): Promise<boolean> {
+    try {
+      const response = await firstValueFrom(
+        this.http.post<{ success: boolean; error?: string }>(
+          `${this.backendURL}/users/status`,
+          { userId, status }
+        )
+      );
+
+      if (response.success) {
+        return true;
+      } else {
+        console.error(response.error);
+      }
+    } catch (error) {
+      console.error('Error updating status:', error);
+    }
+    return false;
+  }
+
   //////////////////////////// TEAMS ////////////////////////////
 
   // Get all teams of which the user is a member

--- a/chathaven/frontend/src/services/user.service.ts
+++ b/chathaven/frontend/src/services/user.service.ts
@@ -16,13 +16,16 @@ export class UserService {
   constructor(private backendService: BackendService) {}
 
   async setUser(user: IUser) {
+
+    localStorage.setItem('currentUserUID', user.userId);
+
     const success = await this.backendService.updateStatus(user.userId, 'online');
     if (success) {
       user.status = 'online';
-      this.userSubject.next(user);
-      this.userStatusSubject.next('online');
     }
-    localStorage.setItem('currentUserUID', user.userId);
+    
+    this.userSubject.next(user);
+    this.userStatusSubject.next('online');
   }
 
   getUser(): IUser | undefined {

--- a/chathaven/frontend/src/services/user.service.ts
+++ b/chathaven/frontend/src/services/user.service.ts
@@ -9,6 +9,9 @@ import { BackendService } from './backend.service';
 export class UserService {
   private userSubject = new BehaviorSubject<IUser | undefined>(undefined);
   user$: Observable<IUser | undefined> = this.userSubject.asObservable();
+  
+  private userStatusSubject = new BehaviorSubject<string>('online');
+  userStatus$ = this.userStatusSubject.asObservable();
 
   constructor(private backendService: BackendService) {}
 
@@ -40,6 +43,15 @@ export class UserService {
     // TODO: get rid of this
     this.userSubject.next(user);
     localStorage.setItem('user', JSON.stringify(user));
+  }
+
+  async updateUserStatus(status: 'online' | 'away' | 'offline') {
+    const currentUser = this.getUser();
+    if (currentUser) {
+      currentUser.status = status;
+      this.userSubject.next(currentUser);
+      this.userStatusSubject.next(status);
+    }
   }
 
   logout() {

--- a/chathaven/shared/interfaces.ts
+++ b/chathaven/shared/interfaces.ts
@@ -26,7 +26,7 @@ export interface IUser {
   teams: string[]; // teamId
   directMessages: string[];
   inbox: IInbox[];
-  status: string;
+  status: 'online' | 'away' | 'offline';
   lastSeen: Date;
 }
 

--- a/chathaven/shared/interfaces.ts
+++ b/chathaven/shared/interfaces.ts
@@ -26,6 +26,8 @@ export interface IUser {
   teams: string[]; // teamId
   directMessages: string[];
   inbox: IInbox[];
+  status: string;
+  lastSeen: Date;
 }
 
 export interface IMessage {


### PR DESCRIPTION
Implemented the status indicator feature on the frontend (user icon --> gear icon --> user status menu), this closes tasks: #150 and #151 

User clicks the "user icon button" --> "user setting button" --> then a user status menu is displayed.

User can select between 3 statuses:
- Online
- Away
- Offline

When the user selects a user status, their status is changed and displayed in the information sidebar.

_Status indicator feature implementation:_
- When a user logs in, their status is immediately set to "online"
- When the user logs out, their status is immediately set to "offline"
- If the user is idle for more than 5 minutes, the user's status automatically gets set to "away"
- If the user's status automatically gets set to "away", any keystroke or mouse movement will set their status to "online"

**Bugs fixed:**
- Bug fix: Users appear offline immediately if they log out of their account (closes #152)
- Bug fix: Status synchronization issues with the status setting during login fixed (closes #153) 
- Bug fix: When the user status is manually set to "away" or "offline", any user activity (keystrokes/mouse movement) does not change the status to "online" (closes #154) 